### PR TITLE
Added text property for issueCustomField

### DIFF
--- a/src/entities/issueCustomField.ts
+++ b/src/entities/issueCustomField.ts
@@ -10,6 +10,7 @@ export class IssueCustomFieldValueImpl {
     avatarUrl?: string = '';
     isResolved?: boolean = false;
     color?: FieldStyle = new FieldStyleImpl();
+    text?: string = '';
 }
 
 export interface IssueCustomFieldValue extends IssueCustomFieldValueImpl {


### PR DESCRIPTION
Added text property to fix bug when issues come without value for text custom field

before
![image](https://user-images.githubusercontent.com/151965/85627372-d181b400-b687-11ea-83a3-d974e2e5769b.png)

after
![image](https://user-images.githubusercontent.com/151965/85627581-27565c00-b688-11ea-9842-c8e83139f802.png)

