### PR TITLE
Added Bring Your Own Axios Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ import {Youtrack} from "youtrack-rest-client";
 
 const config = {
     baseUrl: "http://example.myjetbrains.com", 
-    token: "perm:your-token"
+    token: "perm:your-token",
+    // optional
+    axiosInstance: axios.create({
+        // your config here
+    })
 };
 const youtrack = new Youtrack(config);
 ```

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,3 +1,0 @@
-import axios from "axios";
-
-export const axiosInstance = axios.create();

--- a/src/options/youtrack_options.ts
+++ b/src/options/youtrack_options.ts
@@ -1,5 +1,8 @@
+import { AxiosInstance } from 'axios';
+
 export interface YoutrackOptions {
     baseUrl: string;
+    axiosInstance?: AxiosInstance;
 }
 
 export interface YoutrackTokenOptions extends YoutrackOptions {

--- a/src/youtrack.ts
+++ b/src/youtrack.ts
@@ -9,14 +9,15 @@ import {AgileEndpoint} from "./endpoints/agile";
 import {SprintEndpoint} from "./endpoints/sprint";
 import {WorkItemEndpoint} from "./endpoints/workitem";
 import {CommentEndpoint} from "./endpoints/comment";
-import {axiosInstance} from "./axios";
-import {AxiosRequestConfig} from "axios/index";
+import axios from "axios";
+import {AxiosRequestConfig, AxiosInstance} from "axios/index";
 import {YoutrackClient} from "./youtrack_client";
 import {GetRequestOptions, RequestOptions} from "./options/request_options";
 
 export class Youtrack implements YoutrackClient {
 
     private readonly baseUrl: string;
+    private readonly axiosInstance: AxiosInstance;
     private defaultRequestOptions: RequestOptions = {};
     public readonly users: UserEndpoint;
     public readonly tags: TagEndpoint;
@@ -35,6 +36,7 @@ export class Youtrack implements YoutrackClient {
             }
         };
         this.baseUrl = this.formBaseUrl(options.baseUrl);
+        this.axiosInstance = options.axiosInstance || axios.create();
         this.users = new UserEndpoint(this);
         this.tags = new TagEndpoint(this);
         this.issues = new IssueEndpoint(this);
@@ -81,7 +83,7 @@ export class Youtrack implements YoutrackClient {
     }
 
     private executeRequest(method: string, url: string, params: AxiosRequestConfig): Promise<any> {
-        return axiosInstance({
+        return this.axiosInstance({
             method: method,
             url: url,
             baseURL: this.baseUrl,


### PR DESCRIPTION
Adds an extra config option `axiosInstance` allowing the user to provide their own instance of Axios with their own request options.
